### PR TITLE
Added `captureGroup` function.

### DIFF
--- a/src/VerbalExpressions.elm
+++ b/src/VerbalExpressions.elm
@@ -1,155 +1,155 @@
-module VerbalExpressions exposing (VerbalExpression, verex, startOfLine, endOfLine, followedBy, find, possibly, anything, anythingBut, something, somethingBut, lineBreak, tab, word, anyOf, range, withAnyCase, repeatPrevious, repeatPrevious2, multiple, multiple2, orElse, beginCapture, endCapture, toRegex, toString, replace)
+module VerbalExpressions exposing (VerbalExpression, anyOf, anything, anythingBut, beginCapture, endCapture, endOfLine, find, followedBy, lineBreak, multiple, multiple2, orElse, possibly, range, repeatPrevious, repeatPrevious2, replace, something, somethingBut, startOfLine, tab, toRegex, toString, verex, withAnyCase, word)
 
 {-| Elm port of [VerbalExpressions](https://github.com/VerbalExpressions)
 @docs verex, startOfLine, endOfLine, followedBy, find, possibly, anything, anythingBut, something, somethingBut, lineBreak, tab, word, anyOf, range, withAnyCase, repeatPrevious, repeatPrevious2, multiple, multiple2, orElse, beginCapture, endCapture, toRegex, toString, replace, VerbalExpression
 -}
 
-import String
 import Regex exposing (Regex)
+import String
 
 
 {-| The main type used for constructing verbal expressions
 -}
 type alias VerbalExpression =
-  { prefixes : String
-  , source : String
-  , suffixes : String
-  , modifiers :
-      { insensitive : Bool
-      , multiline : Bool
-      }
-  }
+    { prefixes : String
+    , source : String
+    , suffixes : String
+    , modifiers :
+        { insensitive : Bool
+        , multiline : Bool
+        }
+    }
 
 
 {-| An initial, empty verex to start from and pipe through functions
 -}
 verex : VerbalExpression
 verex =
-  { prefixes = ""
-  , source = ""
-  , suffixes = ""
-  , modifiers =
-      { insensitive = False
-      , multiline = True
-      }
-  }
+    { prefixes = ""
+    , source = ""
+    , suffixes = ""
+    , modifiers =
+        { insensitive = False
+        , multiline = True
+        }
+    }
 
 
 wrapWith : String -> String -> String -> String
 wrapWith start end value =
-  start ++ value ++ end
+    start ++ value ++ end
 
 
 add : String -> VerbalExpression -> VerbalExpression
 add value expression =
-  { expression
-    | source = expression.source ++ value
-  }
+    { expression
+        | source = expression.source ++ value
+    }
 
 
 {-| Restrict matches to start of line
 -}
 startOfLine : VerbalExpression -> VerbalExpression
 startOfLine expression =
-  { expression | prefixes = "^" ++ expression.prefixes }
+    { expression | prefixes = "^" ++ expression.prefixes }
 
 
 {-| Restrict matches to end of line
 -}
 endOfLine : VerbalExpression -> VerbalExpression
 endOfLine expression =
-  { expression | suffixes = expression.suffixes ++ "$" }
+    { expression | suffixes = expression.suffixes ++ "$" }
 
 
 {-| Include a matching group in the expression
 -}
 followedBy : String -> VerbalExpression -> VerbalExpression
 followedBy value =
-  value
-    |> wrapWith "(?:" ")"
-    |> add
+    value
+        |> wrapWith "(?:" ")"
+        |> add
 
 
 {-| Start the expression with a matching group
 -}
 find : String -> VerbalExpression -> VerbalExpression
 find =
-  followedBy
+    followedBy
 
 
 {-| Include an optional matching group
 -}
 possibly : String -> VerbalExpression -> VerbalExpression
 possibly value =
-  value |> wrapWith "(?:" ")?" |> add
+    value |> wrapWith "(?:" ")?" |> add
 
 
 {-| Match any set of characters or not
 -}
 anything : VerbalExpression -> VerbalExpression
 anything =
-  add "(?:.*)"
+    add "(?:.*)"
 
 
 {-| Match any set of characters except a particular String
 -}
 anythingBut : String -> VerbalExpression -> VerbalExpression
 anythingBut value =
-  value |> wrapWith "(?:[^" "]*)" |> add
+    value |> wrapWith "(?:[^" "]*)" |> add
 
 
 {-| Match on one or more characters
 -}
 something : VerbalExpression -> VerbalExpression
 something =
-  add "(?:.+)"
+    add "(?:.+)"
 
 
 {-| Match on one or more characters, with the execption of some String
 -}
 somethingBut : String -> VerbalExpression -> VerbalExpression
 somethingBut value =
-  value |> wrapWith "(?:[^" "]+)" |> add
+    value |> wrapWith "(?:[^" "]+)" |> add
 
 
 {-| Match a new line
 -}
 lineBreak : VerbalExpression -> VerbalExpression
 lineBreak =
-  add "(?:\\r\\n|\\r|\\n)"
+    add "(?:\\r\\n|\\r|\\n)"
 
 
 {-| Match a tab
 -}
 tab : VerbalExpression -> VerbalExpression
 tab =
-  add "\\t"
+    add "\\t"
 
 
 {-| Match an alphanumeric word
 -}
 word : VerbalExpression -> VerbalExpression
 word =
-  add "\\w+"
+    add "\\w+"
 
 
 {-| Match a character class
 -}
 anyOf : String -> VerbalExpression -> VerbalExpression
 anyOf value =
-  value |> wrapWith "[" "]" |> add
+    value |> wrapWith "[" "]" |> add
 
 
 {-| Match a character class with ranges
 -}
 range : List ( String, String ) -> VerbalExpression -> VerbalExpression
 range args =
-  let
-    rendered =
-      args
-        |> List.map (\( left, right ) -> left ++ "-" ++ right)
-        |> String.join ""
-  in
+    let
+        rendered =
+            args
+                |> List.map (\( left, right ) -> left ++ "-" ++ right)
+                |> String.join ""
+    in
     rendered |> wrapWith "[" "]" |> add
 
 
@@ -157,11 +157,11 @@ range args =
 -}
 withAnyCase : Bool -> VerbalExpression -> VerbalExpression
 withAnyCase enable expression =
-  let
-    modifiers =
-      expression.modifiers
-        |> \mod -> { mod | insensitive = enable }
-  in
+    let
+        modifiers =
+            expression.modifiers
+                |> (\mod -> { mod | insensitive = enable })
+    in
     { expression | modifiers = modifiers }
 
 
@@ -169,11 +169,11 @@ withAnyCase enable expression =
 -}
 searchOneLine : Bool -> VerbalExpression -> VerbalExpression
 searchOneLine enable expression =
-  let
-    modifiers =
-      expression.modifiers
-        |> \mod -> { mod | multiline = not enable }
-  in
+    let
+        modifiers =
+            expression.modifiers
+                |> (\mod -> { mod | multiline = not enable })
+    in
     { expression | modifiers = modifiers }
 
 
@@ -181,36 +181,36 @@ searchOneLine enable expression =
 -}
 repeatPrevious : Int -> VerbalExpression -> VerbalExpression
 repeatPrevious times =
-  times |> Basics.toString |> wrapWith "{" "}" |> add
+    times |> Basics.toString |> wrapWith "{" "}" |> add
 
 
 {-| Repeat the prior case within some range of times
 -}
 repeatPrevious2 : Int -> Int -> VerbalExpression -> VerbalExpression
 repeatPrevious2 start end =
-  ((Basics.toString start) ++ "," ++ (Basics.toString end))
-    |> wrapWith "{" "}"
-    |> add
+    (Basics.toString start ++ "," ++ Basics.toString end)
+        |> wrapWith "{" "}"
+        |> add
 
 
 {-| Match a group any number of times
 -}
 multiple : String -> VerbalExpression -> VerbalExpression
 multiple value =
-  value |> wrapWith "(?:" ")*" |> add
+    value |> wrapWith "(?:" ")*" |> add
 
 
 {-| Match a group a particular number of times
 -}
 multiple2 : String -> Int -> VerbalExpression -> VerbalExpression
 multiple2 value times =
-  let
-    value_ =
-      value |> wrapWith "(?:" ")"
+    let
+        value_ =
+            value |> wrapWith "(?:" ")"
 
-    times_ =
-      times |> Basics.toString |> wrapWith "{" "}"
-  in
+        times_ =
+            times |> Basics.toString |> wrapWith "{" "}"
+    in
     add (value_ ++ times_)
 
 
@@ -218,45 +218,46 @@ multiple2 value times =
 -}
 orElse : String -> VerbalExpression -> VerbalExpression
 orElse value expression =
-  let
-    updatedPrefixes =
-      expression.prefixes ++ "(?:"
+    let
+        updatedPrefixes =
+            expression.prefixes ++ "(?:"
 
-    updatedSuffixes =
-      ")" ++ expression.suffixes
-  in
+        updatedSuffixes =
+            ")" ++ expression.suffixes
+    in
     expression
-      |> add ")|(?:"
-      |> followedBy value
-      |> \exp ->
-          { exp | prefixes = updatedPrefixes }
-            |> \exp -> { exp | suffixes = updatedSuffixes }
+        |> add ")|(?:"
+        |> followedBy value
+        |> (\exp ->
+                { exp | prefixes = updatedPrefixes }
+                    |> (\exp -> { exp | suffixes = updatedSuffixes })
+           )
 
 
 {-| Start capturing a group
 -}
 beginCapture : VerbalExpression -> VerbalExpression
 beginCapture expression =
-  let
-    updatedSuffixes =
-      ")" ++ expression.suffixes
-  in
+    let
+        updatedSuffixes =
+            ")" ++ expression.suffixes
+    in
     expression
-      |> add "("
-      |> \exp -> { exp | suffixes = updatedSuffixes }
+        |> add "("
+        |> (\exp -> { exp | suffixes = updatedSuffixes })
 
 
 {-| Finish capturing a group
 -}
 endCapture : VerbalExpression -> VerbalExpression
 endCapture expression =
-  let
-    updatedSuffixes =
-      String.dropLeft 1 expression.suffixes
-  in
+    let
+        updatedSuffixes =
+            String.dropLeft 1 expression.suffixes
+    in
     expression
-      |> add ")"
-      |> \exp -> { exp | suffixes = updatedSuffixes }
+        |> add ")"
+        |> (\exp -> { exp | suffixes = updatedSuffixes })
 
 
 {-| Compile result down to a String
@@ -264,26 +265,26 @@ Note, this is just a string of the expression. Modifier flags are discarded.
 -}
 toString : VerbalExpression -> String
 toString expression =
-  expression.prefixes ++ expression.source ++ expression.suffixes
+    expression.prefixes ++ expression.source ++ expression.suffixes
 
 
 {-| Compile result down to a Regex.regex
 -}
 toRegex : VerbalExpression -> Regex
 toRegex expression =
-  let
-    joined =
-      toString expression
+    let
+        joined =
+            toString expression
 
-    initialOutput =
-      Regex.regex joined
+        initialOutput =
+            Regex.regex joined
 
-    flaggedOutput =
-      if expression.modifiers.insensitive then
-        Regex.caseInsensitive initialOutput
-      else
-        initialOutput
-  in
+        flaggedOutput =
+            if expression.modifiers.insensitive then
+                Regex.caseInsensitive initialOutput
+            else
+                initialOutput
+    in
     flaggedOutput
 
 
@@ -292,4 +293,4 @@ created using VerbalExpressions
 -}
 replace : Regex.HowMany -> String -> String -> Regex -> String
 replace howMany replacement input regex =
-  Regex.replace howMany regex (always replacement) input
+    Regex.replace howMany regex (always replacement) input

--- a/src/VerbalExpressions.elm
+++ b/src/VerbalExpressions.elm
@@ -1,7 +1,7 @@
-module VerbalExpressions exposing (VerbalExpression, anyOf, anything, anythingBut, beginCapture, endCapture, endOfLine, find, followedBy, lineBreak, multiple, multiple2, orElse, possibly, range, repeatPrevious, repeatPrevious2, replace, something, somethingBut, startOfLine, tab, toRegex, toString, verex, withAnyCase, word)
+module VerbalExpressions exposing (VerbalExpression, anyOf, anything, anythingBut, beginCapture, captureGroup, endCapture, endOfLine, find, followedBy, lineBreak, multiple, multiple2, orElse, possibly, range, repeatPrevious, repeatPrevious2, replace, something, somethingBut, startOfLine, tab, toRegex, toString, verex, withAnyCase, word)
 
 {-| Elm port of [VerbalExpressions](https://github.com/VerbalExpressions)
-@docs verex, startOfLine, endOfLine, followedBy, find, possibly, anything, anythingBut, something, somethingBut, lineBreak, tab, word, anyOf, range, withAnyCase, repeatPrevious, repeatPrevious2, multiple, multiple2, orElse, beginCapture, endCapture, toRegex, toString, replace, VerbalExpression
+@docs verex, startOfLine, endOfLine, followedBy, find, possibly, anything, anythingBut, something, somethingBut, lineBreak, tab, word, anyOf, range, withAnyCase, repeatPrevious, repeatPrevious2, multiple, multiple2, orElse, beginCapture, endCapture, captureGroup, toRegex, toString, replace, VerbalExpression
 -}
 
 import Regex exposing (Regex)
@@ -258,6 +258,13 @@ endCapture expression =
     expression
         |> add ")"
         |> (\exp -> { exp | suffixes = updatedSuffixes })
+
+
+{-| Captures a group
+-}
+captureGroup : VerbalExpression -> VerbalExpression
+captureGroup expression =
+    beginCapture >> expression >> endCapture
 
 
 {-| Compile result down to a String

--- a/test/TestRunner.elm
+++ b/test/TestRunner.elm
@@ -1,15 +1,17 @@
-module Main where
+module Main exposing (..)
 
-import Signal exposing (Signal)
-
-import ElmTest exposing (consoleRunner)
 import Console exposing (IO, run)
+import ElmTest exposing (consoleRunner)
+import Signal exposing (Signal)
 import Task
-
 import Tests
 
+
 console : IO ()
-console = consoleRunner Tests.all
+console =
+    consoleRunner Tests.all
+
 
 port runner : Signal (Task.Task x ())
-port runner = run console
+port runner =
+    run console

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -1,231 +1,251 @@
-module Tests where
+module Tests exposing (..)
 
 import ElmTest exposing (..)
-
-import VerbalExpressions exposing (..)
 import Regex
+import VerbalExpressions exposing (..)
+
 
 all : Test
 all =
-  suite "A Test Suite"
-    [ suite "something"
-      [ test "empty string doesn't have something" somethingEmptyTest
-      , test "'a' is something" somethingNotEmptyTest
-      ]
-    , suite "anything"
-      [ test "matches anything" anythingTest
-      ]
-    , suite "anythingBut"
-      [ test "starts with w" anythingButTest
-      ]
-    , suite "somethingBut"
-      [ test "empty string doesn't have something" somethingButEmptyTest
-      , test "doesn't start with 'a'" somethingButMatchTest
-      , test "starts with 'a'" somethingButMismatchTest
-      ]
-    , suite "startOfLine"
-      [ test "starts with 'a'" startOfLineMatchTest
-      , test "doesn't start with 'a'" startOfLineMismatchTest
-      ]
-    , suite "endOfLine"
-      [ test "ends with 'a'" endOfLineMatchTest
-      , test "doesn't end with 'a'" endOfLineMismatchTest
-      ]
-    , suite "possibly"
-      [ test "with a match" possiblyWithMatchTest
-      , test "without a match" possiblyWithoutMatchTest
-      ]
-    , suite "anyOf"
-      [ test "has an x, y, or z after an a" anyOfMatchTest
-      , test "doesn't have an x, y, or z after an a" anyOfMismatchTest
-      ]
-    , suite "orElse"
-      [ test "starts with abc or def" orElseMatchTest
-      , test "doesn't start with abc or def" orElseMismatchTest
-      ]
-    , suite "lineBreak"
-      [ test "abc then line break then def" lineBreakTest
-      ]
-    , suite "tab"
-      [ test "tab then def" tabTest
-      ]
-    , suite "withAnyCase"
-      [ test "lowercase 'a' matches uppercase 'A'" withAnyCaseTest
-      ]
-    , suite "toString"
-      [ test "can be stringified" toStringCaseTest
-      ]
-    ]
+    suite "A Test Suite"
+        [ suite "something"
+            [ test "empty string doesn't have something" somethingEmptyTest
+            , test "'a' is something" somethingNotEmptyTest
+            ]
+        , suite "anything"
+            [ test "matches anything" anythingTest
+            ]
+        , suite "anythingBut"
+            [ test "starts with w" anythingButTest
+            ]
+        , suite "somethingBut"
+            [ test "empty string doesn't have something" somethingButEmptyTest
+            , test "doesn't start with 'a'" somethingButMatchTest
+            , test "starts with 'a'" somethingButMismatchTest
+            ]
+        , suite "startOfLine"
+            [ test "starts with 'a'" startOfLineMatchTest
+            , test "doesn't start with 'a'" startOfLineMismatchTest
+            ]
+        , suite "endOfLine"
+            [ test "ends with 'a'" endOfLineMatchTest
+            , test "doesn't end with 'a'" endOfLineMismatchTest
+            ]
+        , suite "possibly"
+            [ test "with a match" possiblyWithMatchTest
+            , test "without a match" possiblyWithoutMatchTest
+            ]
+        , suite "anyOf"
+            [ test "has an x, y, or z after an a" anyOfMatchTest
+            , test "doesn't have an x, y, or z after an a" anyOfMismatchTest
+            ]
+        , suite "orElse"
+            [ test "starts with abc or def" orElseMatchTest
+            , test "doesn't start with abc or def" orElseMismatchTest
+            ]
+        , suite "lineBreak"
+            [ test "abc then line break then def" lineBreakTest
+            ]
+        , suite "tab"
+            [ test "tab then def" tabTest
+            ]
+        , suite "withAnyCase"
+            [ test "lowercase 'a' matches uppercase 'A'" withAnyCaseTest
+            ]
+        , suite "toString"
+            [ test "can be stringified" toStringCaseTest
+            ]
+        ]
+
 
 somethingEmptyTest : Assertion
 somethingEmptyTest =
-  let
-    testEx =
-      verex
-        |> something
-        |> toRegex
-  in
+    let
+        testEx =
+            verex
+                |> something
+                |> toRegex
+    in
     assertEqual False (Regex.contains testEx "")
+
 
 somethingNotEmptyTest : Assertion
 somethingNotEmptyTest =
-  let
-    testEx =
-      verex
-        |> something
-        |> toRegex
-  in
+    let
+        testEx =
+            verex
+                |> something
+                |> toRegex
+    in
     assertEqual True (Regex.contains testEx "a")
+
 
 anythingTest : Assertion
 anythingTest =
-  let
-    testEx =
-      verex |> startOfLine |> anything |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> anything |> toRegex
+    in
     assertEqual True (Regex.contains testEx "awiorllkhahl124559a agaogg87")
+
 
 anythingButTest : Assertion
 anythingButTest =
-  let
-    testEx =
-      verex |> startOfLine |> anythingBut "w" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> anythingBut "w" |> toRegex
+    in
     assertEqual True (Regex.contains testEx "what")
+
 
 somethingButEmptyTest : Assertion
 somethingButEmptyTest =
-  let
-    testEx =
-      verex |> somethingBut "a" |> toRegex
-  in
+    let
+        testEx =
+            verex |> somethingBut "a" |> toRegex
+    in
     assertEqual False (Regex.contains testEx "")
+
 
 somethingButMatchTest : Assertion
 somethingButMatchTest =
-  let
-    testEx =
-      verex |> somethingBut "a" |> toRegex
-  in
+    let
+        testEx =
+            verex |> somethingBut "a" |> toRegex
+    in
     assertEqual True (Regex.contains testEx "b")
+
 
 somethingButMismatchTest : Assertion
 somethingButMismatchTest =
-  let
-    testEx =
-      verex |> somethingBut "a" |> toRegex
-  in
+    let
+        testEx =
+            verex |> somethingBut "a" |> toRegex
+    in
     assertEqual False (Regex.contains testEx "a")
+
 
 startOfLineMatchTest : Assertion
 startOfLineMatchTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "a" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "a" |> toRegex
+    in
     assertEqual True (Regex.contains testEx "ab")
+
 
 startOfLineMismatchTest : Assertion
 startOfLineMismatchTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "a" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "a" |> toRegex
+    in
     assertEqual False (Regex.contains testEx "ba")
+
 
 endOfLineMatchTest : Assertion
 endOfLineMatchTest =
-  let
-    testEx =
-      verex |> find "a" |> endOfLine |> toRegex
-  in
+    let
+        testEx =
+            verex |> find "a" |> endOfLine |> toRegex
+    in
     assertEqual True (Regex.contains testEx "ba")
+
 
 endOfLineMismatchTest : Assertion
 endOfLineMismatchTest =
-  let
-    testEx =
-      verex |> find "a" |> endOfLine |> toRegex
-  in
+    let
+        testEx =
+            verex |> find "a" |> endOfLine |> toRegex
+    in
     assertEqual False (Regex.contains testEx "ab")
+
 
 possiblyWithMatchTest : Assertion
 possiblyWithMatchTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "a" |> possibly "b" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "a" |> possibly "b" |> toRegex
+    in
     assertEqual True (Regex.contains testEx "abc")
+
 
 possiblyWithoutMatchTest : Assertion
 possiblyWithoutMatchTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "a" |> possibly "b" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "a" |> possibly "b" |> toRegex
+    in
     assertEqual True (Regex.contains testEx "acd")
+
 
 anyOfMatchTest : Assertion
 anyOfMatchTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "a" |> anyOf "xyz" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "a" |> anyOf "xyz" |> toRegex
+    in
     assertEqual True (Regex.contains testEx "ay")
+
 
 anyOfMismatchTest : Assertion
 anyOfMismatchTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "a" |> anyOf "xyz" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "a" |> anyOf "xyz" |> toRegex
+    in
     assertEqual False (Regex.contains testEx "ab")
+
 
 orElseMatchTest : Assertion
 orElseMatchTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "abc" |> orElse "def" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "abc" |> orElse "def" |> toRegex
+    in
     assertEqual True (Regex.contains testEx "defzzz")
 
 
 orElseMismatchTest : Assertion
 orElseMismatchTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "abc" |> orElse "def" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "abc" |> orElse "def" |> toRegex
+    in
     assertEqual False (Regex.contains testEx "zzzabc")
+
 
 lineBreakTest : Assertion
 lineBreakTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "abc" |> lineBreak |> followedBy "def" |> toRegex
-  in
-    assertEqual True (Regex.contains testEx "abc\r\ndef")
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "abc" |> lineBreak |> followedBy "def" |> toRegex
+    in
+    assertEqual True (Regex.contains testEx "abc\x0D\ndef")
+
 
 tabTest : Assertion
 tabTest =
-  let
-    testEx =
-      verex |> startOfLine |> tab |> followedBy "def" |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> tab |> followedBy "def" |> toRegex
+    in
     assertEqual True (Regex.contains testEx "\tdef")
+
 
 withAnyCaseTest : Assertion
 withAnyCaseTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "a" |> withAnyCase True |> toRegex
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "a" |> withAnyCase True |> toRegex
+    in
     assertEqual True (Regex.contains testEx "A")
+
 
 toStringCaseTest : Assertion
 toStringCaseTest =
-  let
-    testEx =
-      verex |> startOfLine |> followedBy "a" |> VerbalExpressions.toString
-  in
+    let
+        testEx =
+            verex |> startOfLine |> followedBy "a" |> VerbalExpressions.toString
+    in
     assertEqual "^(?:a)" testEx


### PR DESCRIPTION
The idea is to have a function which will wrap given expression with group symbols.

E.g.
```
import VerbalExpressions as VerEx

urlExpression =
    VerEx.verex
        |> VerEx.startOfLine
        |> VerEx.possibly "<"
        |> VerEx.captureGroup
            (VerEx.followedBy "http"
                >> VerEx.possibly "s"
                >> VerEx.followedBy "://"
                >> VerEx.somethingBut ">"
            )
        |> VerEx.possibly ">"
        |> VerEx.endOfLine
        |> VerEx.withAnyCase True
```

Additionally I've made elm-format.